### PR TITLE
Fix DateTimeImmutable::createFromFormat() with a pipe character

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 /.gitignore
 /.travis.yml
 /Dockerfile
+/SHA256SUMS
+/timecop_*.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN : \
     && scripts/compile 7.2 /dst \
     && scripts/compile 7.3 /dst \
     && make clean \
+    && (cd /dst && sha256sum timecop_*.so > SHA256SUMS) \
+    && cat /dst/SHA256SUMS \
     && ls -l /dst
 
 CMD : \
     && cd /dst \
-    && tar -cf - *.so | cat
+    && tar -cf - *.so SHA256SUMS | cat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Usage: docker run --rm $(docker build -q .) | tar -x
 FROM ubuntu:18.04
 
 RUN : \

--- a/scripts/compile
+++ b/scripts/compile
@@ -13,5 +13,5 @@ fi
 phpize$PHP_VERSION
 ./configure --with-php-config=$(which php-config$PHP_VERSION)
 make -B
-make test NO_INTERACTION=1 TEST_PHPDBG_EXECUTABLE=$(which phpdbg$PHP_VERSION)
+make test REPORT_EXIT_STATUS=1 NO_INTERACTION=1 TEST_PHPDBG_EXECUTABLE=$(which phpdbg$PHP_VERSION)
 cp modules/timecop.so "$OUTPUT"

--- a/tests/wp_create-from-format-with-pipe.phpt
+++ b/tests/wp_create-from-format-with-pipe.phpt
@@ -1,0 +1,12 @@
+--TEST--
+DateTimeImmutable::createFromFormat() with a pipe character
+--INI--
+date.timezone=GMT
+timecop.func_override=1
+--FILE--
+<?php
+declare(strict_types=1);
+
+echo get_class(\DateTimeImmutable::createFromFormat('Y-m-d|', '2020-01-12'));
+--EXPECT--
+DateTimeImmutable

--- a/tests/wp_create-from-format-with-pipe.phpt
+++ b/tests/wp_create-from-format-with-pipe.phpt
@@ -5,8 +5,6 @@ date.timezone=GMT
 timecop.func_override=1
 --FILE--
 <?php
-declare(strict_types=1);
-
 echo get_class(\DateTimeImmutable::createFromFormat('Y-m-d|', '2020-01-12'));
 --EXPECT--
 DateTimeImmutable

--- a/tests/wp_create-from-format-with-pipe.phpt
+++ b/tests/wp_create-from-format-with-pipe.phpt
@@ -5,6 +5,8 @@ date.timezone=GMT
 timecop.func_override=1
 --FILE--
 <?php
-echo get_class(\DateTimeImmutable::createFromFormat('Y-m-d|', '2020-01-12'));
+echo get_class(\DateTime::createFromFormat('Y-m-d|', '2020-01-12')),"\n";
+echo get_class(\DateTimeImmutable::createFromFormat('Y-m-d|', '2020-01-12')),"\n";
 --EXPECT--
+DateTime
 DateTimeImmutable

--- a/timecop_php5.c
+++ b/timecop_php5.c
@@ -1520,6 +1520,11 @@ static void _timecop_date_create_from_format(INTERNAL_FUNCTION_PARAMETERS, int i
 
 	if (memchr(orig_format_str, '!', orig_format_len) ||
 		memchr(orig_format_str, '|', orig_format_len)) {
+
+		if (immutable) {
+			call_php_function_with_3_params(ORIG_FUNC_NAME("date_create_immutable_from_format"), &dt, &orig_format, &orig_time, orig_timezone);
+		}
+
 		RETURN_ZVAL(dt, 1, 1);
 	}
 

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -1529,6 +1529,11 @@ static void _timecop_date_create_from_format(INTERNAL_FUNCTION_PARAMETERS, int i
 
 	if (memchr(orig_format_str, '!', orig_format_len) ||
 		memchr(orig_format_str, '|', orig_format_len)) {
+
+		if (immutable) {
+			call_php_function_with_3_params(ORIG_FUNC_NAME("date_create_immutable_from_format"), &dt, &orig_format, &orig_time, orig_timezone);
+		}
+
 		zval_ptr_dtor(&orig_format);
 		zval_ptr_dtor(&orig_time);
 		RETURN_ZVAL(&dt, 1, 1);


### PR DESCRIPTION
The following code failed and resulted in a `DateTime` object instead of `DateTimeImmutable`.

```php
\DateTimeImmutable::createFromFormat('Y-m-d|', '2019-02-02');
```