### PR TITLE
Add support for PHP 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,10 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
-[*.c]
+[*.{c,h}]
 indent_style = tab
 indent_size = 4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           - '7.2'
           - '7.3'
           - '7.4'
+          - '8.0'
         valgrind: [false]
         php-zts:
           - nts

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN : \
         php7.2-phpdbg php7.2-dev \
         php7.3-phpdbg php7.3-dev \
         php7.4-phpdbg php7.4-dev \
+        php8.0-phpdbg php8.0-dev \
     && adduser --disabled-password --gecos '' --no-create-home build \
     && mkdir -p /dst \
     && chown build:build /dst
@@ -24,7 +25,7 @@ COPY --chown=build:build . /src
 RUN : \
     && cd src \
     && if [ -f configure ]; then echo "Run git clean -fX" >&2; exit 1; fi \
-    && scripts/compile --output-dir /dst 5.6 7.0 7.1 7.2 7.3 7.4 \
+    && scripts/compile --output-dir /dst 5.6 7.0 7.1 7.2 7.3 7.4 8.0 \
     && make clean \
     && (cd /dst && sha256sum timecop_*.so > SHA256SUMS) \
     && cat /dst/SHA256SUMS \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,7 @@ COPY --chown=build:build . /src
 RUN : \
     && cd src \
     && if [ -f configure ]; then echo "Run git clean -fX" >&2; exit 1; fi \
-    && scripts/compile 5.6 /dst \
-    && scripts/compile 7.0 /dst \
-    && scripts/compile 7.1 /dst \
-    && scripts/compile 7.2 /dst \
-    && scripts/compile 7.3 /dst \
-    && scripts/compile 7.4 /dst \
+    && scripts/compile --output-dir /dst 5.6 7.0 7.1 7.2 7.3 7.4 \
     && make clean \
     && (cd /dst && sha256sum timecop_*.so > SHA256SUMS) \
     && cat /dst/SHA256SUMS \

--- a/php_timecop.h
+++ b/php_timecop.h
@@ -189,19 +189,16 @@ struct timecop_override_class_entry {
 	_call_php_method_with_2_params(obj, ce, method_name, retval, arg1, arg2 TSRMLS_CC)
 
 #define call_php_function_with_0_params(function_name, retval) \
-	_call_php_function_with_0_params(function_name, retval TSRMLS_CC)
+	_call_php_method_with_0_params(NULL, NULL, function_name, retval TSRMLS_CC)
 
 #define call_php_function_with_1_params(function_name, retval, arg1) \
-	_call_php_function_with_1_params(function_name, retval, arg1 TSRMLS_CC)
+	_call_php_method_with_1_params(NULL, NULL, function_name, retval, arg1 TSRMLS_CC)
 
 #define call_php_function_with_2_params(function_name, retval, arg1, arg2) \
-	_call_php_function_with_2_params(function_name, retval, arg1, arg2 TSRMLS_CC)
+	_call_php_method_with_2_params(NULL, NULL, function_name, retval, arg1, arg2 TSRMLS_CC)
 
 #define call_php_function_with_3_params(function_name, retval, arg1, arg2, arg3) \
 	_call_php_function_with_3_params(function_name, retval, arg1, arg2, arg3 TSRMLS_CC)
-
-#define call_php_function_with_params(function_name, retval, param_count, params) \
-	_call_php_function_with_params(function_name, retval, param_count, params TSRMLS_CC)
 
 /* In every utility function you add that needs to use variables 
    in php_timecop_globals, call TSRMLS_FETCH(); after declaring other 

--- a/php_timecop.h
+++ b/php_timecop.h
@@ -210,6 +210,15 @@ struct timecop_override_class_entry {
    examples in any other php module directory.
 */
 
+/* Redeclare macros as no-ops which were removed in PHP 8. */
+#if PHP_VERSION_ID >= 80000
+#define TSRMLS_D void
+#define TSRMLS_DC
+#define TSRMLS_C
+#define TSRMLS_CC
+#define TSRMLS_FETCH()
+#endif
+
 #if PHP_VERSION_ID >= 70000
 #  define TIMECOP_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(timecop, v)
 #  if defined(ZTS) && defined(COMPILE_DL_TIMECOP)

--- a/scripts/compile
+++ b/scripts/compile
@@ -1,17 +1,93 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eu
+main() {
+    set -euo pipefail
 
-PHP_VERSION="$1"; shift
-PHP_API=$(php-config$PHP_VERSION --phpapi)
-OUTPUT="$1/timecop_${PHP_API}.so"; shift
+    local positional=()
+    local key
 
-if [ -f Makefile ]; then
-    make clean
-fi
+    while [ $# -gt 0 ]; do
+        key="$1"
 
-phpize$PHP_VERSION
-./configure --with-php-config=$(which php-config$PHP_VERSION)
-make -B
-make test REPORT_EXIT_STATUS=1 NO_INTERACTION=1 TEST_PHPDBG_EXECUTABLE=$(which phpdbg$PHP_VERSION)
-cp modules/timecop.so "$OUTPUT"
+        case $key in
+            --output-dir)
+                readonly OUTPUT_DIR="$2"
+                shift # past argument
+                shift # past value
+            ;;
+            -h|--help)
+                usage
+                return 0
+            ;;
+            -*)
+                usage >&2
+                return 1
+            ;;
+            *) # unknown option
+                positional+=("$1")
+                shift
+            ;;
+        esac
+    done
+    set -- "${positional[@]}" # restore positional parameters
+
+   compile_each "$@"
+}
+
+usage() {
+    echo "${0} [--output-dir DIR] [PHP1] [PHP2] [PHPn]"
+    echo ""
+    echo "Example:"
+    echo "${0} --output-dir /tmp 8.0 7.4"
+    echo
+}
+
+compile_each() {
+    local php_version
+    local php_api
+    local bin_php
+    local bin_phpdbg
+    local bin_phpconfig
+
+    while [ $# -gt 0 ]; do
+        php_version="$1"; shift
+        bin_php="$(php_binary php ${php_version})"
+        if [ "${php_version:0:1}" = "5" ]; then
+            bin_phpdbg=
+        else
+            bin_phpdbg="$(php_binary phpdbg ${php_version})"
+        fi
+        bin_phpconfig="$(php_binary php-config ${php_version})"
+        php_api="$($bin_phpconfig --phpapi)"
+
+        if [ -f Makefile ]; then
+            make clean
+        fi
+
+        phpize${php_version}
+        ./configure --with-php-config="$bin_phpconfig"
+        make -B PHP_EXECUTABLE="$bin_php"
+        make test REPORT_EXIT_STATUS=1 NO_INTERACTION=1 PHP_EXECUTABLE="$bin_php" TEST_PHP_EXECUTABLE="$bin_php" TEST_PHPDBG_EXECUTABLE="$bin_phpdbg"
+
+        if [ ! -z "${OUTPUT_DIR:-}" ]; then
+            cp modules/timecop.so "${OUTPUT_DIR}/timecop_${php_api}.so"
+        fi
+    done
+}
+
+php_binary() {
+    local binary="$1"; shift
+    local version="$1"; shift
+
+    local result="$(which "${binary}${version}")"
+
+    if [ -z "$result" ]; then
+        echo "Cannot find ${binary}${version}, is it installed?" >&2
+
+        return 1
+    fi
+
+    echo "$result"
+}
+
+main "$@"

--- a/tests/issue_043_php8.phpt
+++ b/tests/issue_043_php8.phpt
@@ -2,7 +2,7 @@
 Check for issue #43 (Overridden functions ignore declare(strict_types=1))
 --SKIPIF--
 <?php
-$required_php_major_version = 7;
+$required_version = "8.0";
 $required_func = array("strtotime");
 include(__DIR__."/tests-skipcheck.inc.php");
 --INI--
@@ -19,4 +19,4 @@ try {
 	echo $e->getMessage();
 }
 --EXPECT--
-timecop_strtotime() expects parameter 1 to be string, null given
+timecop_strtotime(): Argument #1 ($time) must be of type string, null given

--- a/tests/tests-skipcheck.inc.php
+++ b/tests/tests-skipcheck.inc.php
@@ -27,3 +27,8 @@ if (isset($required_method)) {
         }
     }
 }
+if (isset($required_php_major_version)) {
+    if ($required_php_major_version !== \PHP_MAJOR_VERSION) {
+        die("skip PHP ${required_php_major_version}.x required for this test.");
+    }
+}

--- a/timecop_php5.c
+++ b/timecop_php5.c
@@ -353,9 +353,6 @@ static inline zval* _call_php_method_with_0_params(zval **object_pp, zend_class_
 static inline zval* _call_php_method_with_1_params(zval **object_pp, zend_class_entry *obj_ce, const char *method_name, zval **retval_ptr_ptr, zval *arg1 TSRMLS_DC);
 static inline zval* _call_php_method_with_2_params(zval **object_pp, zend_class_entry *obj_ce, const char *method_name, zval **retval_ptr_ptr, zval *arg1, zval *arg2 TSRMLS_DC);
 static inline zval* _call_php_method(zval **object_pp, zend_class_entry *obj_ce, const char *method_name, zval **retval_ptr_ptr, int param_count, zval* arg1, zval* arg2 TSRMLS_DC);
-static inline void _call_php_function_with_0_params(const char *function_name, zval **retval_ptr_ptr TSRMLS_DC);
-static inline void _call_php_function_with_1_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1 TSRMLS_DC);
-static inline void _call_php_function_with_2_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1, zval *arg2 TSRMLS_DC);
 static void _call_php_function_with_3_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1, zval *arg2, zval *arg3 TSRMLS_DC);
 static inline void _call_php_function_with_params(const char *function_name, zval **retval_ptr_ptr, zend_uint param_count, zval **params[] TSRMLS_DC);
 
@@ -998,7 +995,7 @@ static void _timecop_call_function(INTERNAL_FUNCTION_PARAMETERS, const char *fun
 		argc++;
 	}
 
-	call_php_function_with_params(function_name, &retval_ptr, argc, params);
+	_call_php_function_with_params(function_name, &retval_ptr, argc, params TSRMLS_CC);
 
 	efree(params);
 
@@ -1034,7 +1031,7 @@ static void _timecop_call_mktime(INTERNAL_FUNCTION_PARAMETERS, const char *mktim
 		php_error_docref(NULL TSRMLS_CC, E_STRICT, "You should be using the time() function instead");
 	}
 
-	call_php_function_with_params(mktime_function_name, &retval_ptr, params_size, params);
+	_call_php_function_with_params(mktime_function_name, &retval_ptr, params_size, params TSRMLS_CC);
 
 	for (i = argc; i < MKTIME_NUM_ARGS; i++) {
 		zval_ptr_dtor(&filled_value[i]);
@@ -1720,23 +1717,10 @@ static inline zval* _call_php_method(zval **object_pp, zend_class_entry *obj_ce,
 	return zend_call_method(object_pp, obj_ce, NULL, method_name, strlen(method_name), retval_ptr_ptr, param_count, arg1, arg2 TSRMLS_CC);
 }
 
-static inline void _call_php_function_with_0_params(const char *function_name, zval **retval_ptr_ptr TSRMLS_DC)
-{
-	_call_php_method_with_0_params(NULL, NULL, function_name, retval_ptr_ptr TSRMLS_CC);
-}
-
-static inline void _call_php_function_with_1_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1 TSRMLS_DC)
-{
-	_call_php_method_with_1_params(NULL, NULL, function_name, retval_ptr_ptr, arg1 TSRMLS_CC);
-}
-static inline void _call_php_function_with_2_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1, zval *arg2 TSRMLS_DC)
-{
-	_call_php_method_with_2_params(NULL, NULL, function_name, retval_ptr_ptr, arg1, arg2 TSRMLS_CC);
-}
 static void _call_php_function_with_3_params(const char *function_name, zval **retval_ptr_ptr, zval *arg1, zval *arg2, zval *arg3 TSRMLS_DC)
 {
 	if (arg3 == NULL) {
-		_call_php_function_with_2_params(function_name, retval_ptr_ptr, arg1, arg2 TSRMLS_CC);
+		call_php_function_with_2_params(function_name, retval_ptr_ptr, arg1, arg2 TSRMLS_CC);
 	} else {
 		zval *zps[3] = {arg1, arg2, arg3};
 		zval **params[3] = {&zps[0], &zps[1], &zps[2]};

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -1723,7 +1723,7 @@ static inline void _call_php_function_with_params(const char *function_name, zva
 	zval callable;
 	ZVAL_STRING(&callable, function_name);
 
-	call_user_function_ex(EG(function_table), NULL, &callable, retval_ptr, param_count, params, 1, NULL);
+	call_user_function(EG(function_table), NULL, &callable, retval_ptr, param_count, params);
 
 	zval_ptr_dtor(&callable);
 }

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -305,9 +305,6 @@ static inline zval* _call_php_method_with_0_params(zval *object_pp, zend_class_e
 static inline zval* _call_php_method_with_1_params(zval *object_pp, zend_class_entry *obj_ce, const char *method_name, zval *retval_ptr, zval *arg1);
 static inline zval* _call_php_method_with_2_params(zval *object_pp, zend_class_entry *obj_ce, const char *method_name, zval *retval_ptr, zval *arg1, zval *arg2);
 static inline zval* _call_php_method(zval *object_pp, zend_class_entry *obj_ce, const char *method_name, zval *retval_ptr, int param_count, zval* arg1, zval* arg2);
-static inline void _call_php_function_with_0_params(const char *function_name, zval *retval_ptr);
-static inline void _call_php_function_with_1_params(const char *function_name, zval *retval_ptr, zval *arg1);
-static inline void _call_php_function_with_2_params(const char *function_name, zval *retval_ptr, zval *arg1, zval *arg2);
 static void _call_php_function_with_3_params(const char *function_name, zval *retval_ptr, zval *arg1, zval *arg2, zval *arg3);
 static inline void _call_php_function_with_params(const char *function_name, zval *retval_ptr, uint32_t param_count, zval params[]);
 
@@ -940,7 +937,7 @@ static void _timecop_call_function(INTERNAL_FUNCTION_PARAMETERS, const char *fun
 		param_count++;
 	}
 
-	call_php_function_with_params(function_name, return_value, param_count, params);
+	_call_php_function_with_params(function_name, return_value, param_count, params);
 
 	efree(params);
 }
@@ -972,7 +969,7 @@ static void _timecop_call_mktime(INTERNAL_FUNCTION_PARAMETERS, const char *mktim
 		php_error_docref(NULL, E_DEPRECATED, "You should be using the time() function instead");
 	}
 
-	call_php_function_with_params(mktime_function_name, return_value, param_count, params);
+	_call_php_function_with_params(mktime_function_name, return_value, param_count, params);
 
 	for (i = ZEND_NUM_ARGS(); i < MKTIME_NUM_ARGS; i++) {
 		zval_ptr_dtor(&params[i]);
@@ -1688,34 +1685,33 @@ static inline zval* _call_php_method_with_2_params(zval *object_pp, zend_class_e
 
 static inline zval* _call_php_method(zval *object_pp, zend_class_entry *obj_ce, const char *method_name, zval *retval_ptr, int param_count, zval* arg1, zval* arg2)
 {
-	return zend_call_method(object_pp, obj_ce, NULL, method_name, strlen(method_name), retval_ptr, param_count, arg1, arg2);
-}
-
-static inline void _call_php_function_with_0_params(const char *function_name, zval *retval_ptr)
-{
-	_call_php_method_with_0_params(NULL, NULL, function_name, retval_ptr);
-}
-
-static inline void _call_php_function_with_1_params(const char *function_name, zval *retval_ptr, zval *arg1)
-{
-	_call_php_method_with_1_params(NULL, NULL, function_name, retval_ptr, arg1);
-}
-
-static inline void _call_php_function_with_2_params(const char *function_name, zval *retval_ptr, zval *arg1, zval *arg2)
-{
-	_call_php_method_with_2_params(NULL, NULL, function_name, retval_ptr, arg1, arg2);
+	return zend_call_method(
+#if PHP_MAJOR_VERSION >= 8
+		object_pp == NULL ? NULL : Z_OBJ_P(object_pp),
+#else
+		object_pp,
+#endif
+		obj_ce,
+		NULL,
+		method_name,
+		strlen(method_name),
+		retval_ptr,
+		param_count,
+		arg1,
+		arg2
+	);
 }
 
 static inline void _call_php_function_with_3_params(const char *function_name, zval *retval_ptr, zval *arg1, zval *arg2, zval *arg3)
 {
 	if (arg3 == NULL) {
-		_call_php_function_with_2_params(function_name, retval_ptr, arg1, arg2);
+		call_php_function_with_2_params(function_name, retval_ptr, arg1, arg2);
 	} else {
 		zval params[3];
 		ZVAL_COPY(&params[0], arg1);
 		ZVAL_COPY(&params[1], arg2);
 		ZVAL_COPY(&params[2], arg3);
-		call_php_function_with_params(function_name, retval_ptr, 3, params);
+		_call_php_function_with_params(function_name, retval_ptr, 3, params);
 		zval_ptr_dtor(&params[0]);
 		zval_ptr_dtor(&params[1]);
 		zval_ptr_dtor(&params[2]);


### PR DESCRIPTION
This updates the extension to work with PHP 8.

- Editorconfig fixes
- Simplify PHP function/method calling macro soup
- Remove use of removed function in PHP 8
- Fix tests on PHP7/8 due to differing error messages
- Redeclare macros removed in PHP 8
- Rewrite compile script to be more useful for testing
- Rewrite compile script to be more useful for testing
- Add PHP 8 to build process
