### PR TITLE
Fix error with non standard timezone

### DIFF
--- a/tests/issue_052.phpt
+++ b/tests/issue_052.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Check timezone '+00:00' being allowed
+--SKIPIF--
+<?php
+$required_func = array("timecop_freeze");
+include(__DIR__."/tests-skipcheck.inc.php");
+--INI--
+date.timezone=America/Los_Angeles
+timecop.func_override=1
+--FILE--
+<?php
+$dt1 = new \DateTime('@0', new \DateTimeZone('+00:00'));
+var_dump($dt1->format("Y-m-d H:i:s.uP"));
+
+timecop_freeze(0);
+$dt2 = new \DateTime('@0', new \DateTimeZone('+00:00'));
+var_dump($dt2->format("Y-m-d H:i:s.uP"));
+--EXPECT--
+string(32) "1970-01-01 00:00:00.000000+00:00"
+string(32) "1970-01-01 00:00:00.000000+00:00"

--- a/timecop_php5.c
+++ b/timecop_php5.c
@@ -846,26 +846,11 @@ static int get_formatted_mock_time(zval *time, zval *timezone_obj, zval **retval
 
 	get_mock_timeval(&now, NULL TSRMLS_CC);
 
-	if (timezone_obj && Z_TYPE_P(timezone_obj) == IS_OBJECT) {
-		zval *zonename;
-		call_php_method_with_0_params(&timezone_obj, Z_OBJCE_PP(&timezone_obj), "getname", &zonename);
-		if (zonename) {
-			call_php_function_with_0_params("date_default_timezone_get", &orig_zonename);
-			if (orig_zonename) {
-				call_php_function_with_1_params("date_default_timezone_set", NULL, zonename);
-			}
-			zval_ptr_dtor(&zonename);
-		}
-	}
+	// @todo Restore removed timezone handling code? https://github.com/kiddivouchers/php-timecop/pull/6
 
 	INIT_ZVAL(now_timestamp);
 	ZVAL_LONG(&now_timestamp, now.sec);
 	call_php_function_with_2_params(ORIG_FUNC_NAME("strtotime"), &fixed_sec, time, &now_timestamp);
-
-	if (timezone_obj && Z_TYPE_P(timezone_obj) == IS_OBJECT) {
-		call_php_function_with_1_params("date_default_timezone_set", NULL, orig_zonename);
-		zval_ptr_dtor(&orig_zonename);
-	}
 
 	if (Z_TYPE_P(fixed_sec) == IS_BOOL && !Z_BVAL_P(fixed_sec)) {
 		/* $fixed_sec === false */

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -803,6 +803,8 @@ static int get_formatted_mock_time(zval *time, zval *timezone_obj, zval *retval_
 
 	get_mock_timeval(&now, NULL);
 
+	// @todo Restore removed timezone handling code? https://github.com/kiddivouchers/php-timecop/pull/6
+
 	ZVAL_LONG(&now_timestamp, now.sec);
 	call_php_function_with_2_params(ORIG_FUNC_NAME("strtotime"), &fixed_sec, time, &now_timestamp);
 

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -803,21 +803,8 @@ static int get_formatted_mock_time(zval *time, zval *timezone_obj, zval *retval_
 
 	get_mock_timeval(&now, NULL);
 
-	if (timezone_obj && Z_TYPE_P(timezone_obj) == IS_OBJECT) {
-		zval zonename;
-		call_php_method_with_0_params(timezone_obj, Z_OBJCE_P(timezone_obj), "getname", &zonename);
-		call_php_function_with_0_params("date_default_timezone_get", &orig_zonename);
-		call_php_function_with_1_params("date_default_timezone_set", NULL, &zonename);
-		zval_ptr_dtor(&zonename);
-	}
-
 	ZVAL_LONG(&now_timestamp, now.sec);
 	call_php_function_with_2_params(ORIG_FUNC_NAME("strtotime"), &fixed_sec, time, &now_timestamp);
-
-	if (timezone_obj && Z_TYPE_P(timezone_obj) == IS_OBJECT) {
-		call_php_function_with_1_params("date_default_timezone_set", NULL, &orig_zonename);
-		zval_ptr_dtor(&orig_zonename);
-	}
 
 	if (Z_TYPE(fixed_sec) == IS_FALSE) {
 		ZVAL_FALSE(retval_time);


### PR DESCRIPTION
This fix isn't ideal, I've removed some code which fixes the test and doesn't break any others. I assume this code is actually required to handle some edge cases which are not present in the test suite, I've not been able to work out what they are so until there is a test case for that breaks I think this is the best course.

https://github.com/hnw/php-timecop/issues/52