### PR TITLE
Fix couple of references to the wrong arginfo

### DIFF
--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -118,7 +118,7 @@ const zend_function_entry timecop_functions[] = {
 	PHP_FE(timecop_date_create, arginfo_timecop_date_create)
 	PHP_FE(timecop_date_create_from_format, arginfo_timecop_date_create_from_format)
 	PHP_FE(timecop_date_create_immutable, arginfo_timecop_date_create)
-	PHP_FE(timecop_date_create_immutable_from_format, arginfo_timecop_date_create_from_format)
+	PHP_FE(timecop_date_create_immutable_from_format, arginfo_timecop_date_create_immutable_from_format)
 	{NULL, NULL, NULL}
 };
 /* }}} */
@@ -151,7 +151,7 @@ static zend_function_entry timecop_funcs_orig_date[] = {
 static zend_function_entry timecop_funcs_immutable[] = {
 	PHP_ME(TimecopDateTimeImmutable, __construct, arginfo_class_TimecopDateTimeImmutable___construct,
 		   ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
-	PHP_ME_MAPPING(createFromFormat, timecop_date_create_immutable_from_format, arginfo_timecop_date_create_from_format,
+	PHP_ME_MAPPING(createFromFormat, timecop_date_create_immutable_from_format, arginfo_timecop_date_create_immutable_from_format,
 				   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	{NULL, NULL, NULL}
 };


### PR DESCRIPTION
Build passes right now as these references are aliases to the same definition but for PHP 8 they won't be.

These were missed in #9.
