### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
         php-zts:
           - nts
           # @todo Add ts when setup-php supports ZTS on Ubuntu

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ extension=php_timecop.dll
 ## SYSTEM REQUIREMENTS
 
 - OS: Windows(experimental), Linux, macOS
-- PHP: 5.3.1 - 7.2.x (might work on 5.2.x and 5.3.0, but not tested enough)
+- PHP: 5.6.x - 8.1.x
 - SAPI: Apache, CLI
   - Other SAPIs are not tested, but there is no SAPI-dependent code.
 - non-ZTS(recommended), ZTS

--- a/tests/date_006.phpt
+++ b/tests/date_006.phpt
@@ -9,6 +9,8 @@ date.timezone=America/Los_Angeles
 timecop.func_override=0
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(strtotime("2012-02-29 01:23:45"));
 
 // checking class name of instance
@@ -20,7 +22,14 @@ $dts = array(
     timecop_date_create(),
 
     // constuctor with 1 argument(null)
-    timecop_date_create(null),
+    execute(decorateIfTrue(PHP_VERSION_ID >= 80100, function (\Closure $callback) {
+        return decorateIgnoreDeprecation(
+            'timecop_date_create(): Passing null to parameter #1 ($datetime) of type string is deprecated',
+            $callback
+        );
+    }, function () {
+        return timecop_date_create(null);
+    })),
 
     // constuctor with 1 argument(empty string)
     timecop_date_create(""),

--- a/tests/date_override_002.phpt
+++ b/tests/date_override_002.phpt
@@ -9,6 +9,8 @@ date.timezone=America/Los_Angeles
 timecop.func_override=1
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_orig_strtotime("2012-02-29 01:23:45"));
 
 // checking class name of instance
@@ -20,7 +22,14 @@ $dts = array(
     new DateTime(),
 
     // constuctor with 1 argument(null)
-    new DateTime(NULL),
+    execute(decorateIfTrue(PHP_VERSION_ID >= 80100, function (\Closure $callback) {
+        return decorateIgnoreDeprecation(
+            'TimecopDateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated',
+            $callback
+        );
+    }, function () {
+        return new DateTime(NULL);
+    })),
 
     // constuctor with 1 argument(false)
     new DateTime(false),

--- a/tests/date_override_006.phpt
+++ b/tests/date_override_006.phpt
@@ -9,6 +9,8 @@ date.timezone=America/Los_Angeles
 timecop.func_override=1
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_orig_strtotime("2012-02-29 01:23:45"));
 
 // checking class name of instance
@@ -20,7 +22,14 @@ $dts = array(
     date_create(),
 
     // constuctor with 1 argument(null)
-    date_create(null),
+    execute(decorateIfTrue(PHP_VERSION_ID >= 80100, function (\Closure $callback) {
+        return decorateIgnoreDeprecation(
+            'timecop_date_create(): Passing null to parameter #1 ($datetime) of type string is deprecated',
+            $callback
+        );
+    }, function () {
+        return date_create(null);
+    })),
 
     // constuctor with 1 argument(empty string)
     date_create(""),

--- a/tests/func_010.phpt
+++ b/tests/func_010.phpt
@@ -9,7 +9,18 @@ date.timezone=America/Los_Angeles
 timecop.func_override=0
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(strtotime("2012-02-29 01:23:45"));
-var_dump(timecop_strftime("%Y-%m-%d %H:%M:%S"));
+
+execute(decorateIfTrue(
+    PHP_VERSION_ID >= 80100,
+    function (\Closure $callback) {
+        return decorateIgnoreDeprecation('nope', $callback);
+    },
+    function () {
+        var_dump(timecop_strftime("%Y-%m-%d %H:%M:%S"));
+    }
+));
 --EXPECT--
 string(19) "2012-02-29 01:23:45"

--- a/tests/func_010.phpt
+++ b/tests/func_010.phpt
@@ -16,7 +16,13 @@ timecop_freeze(strtotime("2012-02-29 01:23:45"));
 execute(decorateIfTrue(
     PHP_VERSION_ID >= 80100,
     function (\Closure $callback) {
-        return decorateIgnoreDeprecation('nope', $callback);
+        return decorateIgnoreDeprecation(
+            'Function strftime() is deprecated',
+            decorateIgnoreDeprecation(
+                'Function timecop_strftime() is deprecated',
+                $callback
+            )
+        );
     },
     function () {
         var_dump(timecop_strftime("%Y-%m-%d %H:%M:%S"));

--- a/tests/func_011.phpt
+++ b/tests/func_011.phpt
@@ -9,7 +9,18 @@ date.timezone=America/Los_Angeles
 timecop.func_override=0
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_strtotime("2012-02-29 01:23:45 GMT"));
-var_dump(timecop_gmstrftime("%Y-%m-%d %H:%M:%S"));
+
+execute(decorateIfTrue(
+    PHP_VERSION_ID >= 80100,
+    function (\Closure $callback) {
+        return decorateIgnoreDeprecation('nope', $callback);
+    },
+    function () {
+        var_dump(timecop_gmstrftime("%Y-%m-%d %H:%M:%S"));
+    }
+));
 --EXPECT--
 string(19) "2012-02-29 01:23:45"

--- a/tests/func_011.phpt
+++ b/tests/func_011.phpt
@@ -16,7 +16,13 @@ timecop_freeze(timecop_strtotime("2012-02-29 01:23:45 GMT"));
 execute(decorateIfTrue(
     PHP_VERSION_ID >= 80100,
     function (\Closure $callback) {
-        return decorateIgnoreDeprecation('nope', $callback);
+        return decorateIgnoreDeprecation(
+            'Function gmstrftime() is deprecated',
+            decorateIgnoreDeprecation(
+                'Function timecop_gmstrftime() is deprecated',
+                $callback
+            )
+        );
     },
     function () {
         var_dump(timecop_gmstrftime("%Y-%m-%d %H:%M:%S"));

--- a/tests/func_override_010.phpt
+++ b/tests/func_override_010.phpt
@@ -16,7 +16,13 @@ timecop_freeze(timecop_strtotime("2012-02-29 01:23:45"));
 execute(decorateIfTrue(
     PHP_VERSION_ID >= 80100,
     function (\Closure $callback) {
-        return decorateIgnoreDeprecation('nope', $callback);
+        return decorateIgnoreDeprecation(
+            'Function strftime() is deprecated',
+            decorateIgnoreDeprecation(
+                'Function timecop_strftime() is deprecated',
+                $callback
+            )
+        );
     },
     function () {
         var_dump(strftime("%Y-%m-%d %H:%M:%S"));

--- a/tests/func_override_010.phpt
+++ b/tests/func_override_010.phpt
@@ -9,7 +9,18 @@ date.timezone=America/Los_Angeles
 timecop.func_override=1
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_strtotime("2012-02-29 01:23:45"));
-var_dump(strftime("%Y-%m-%d %H:%M:%S"));
+
+execute(decorateIfTrue(
+    PHP_VERSION_ID >= 80100,
+    function (\Closure $callback) {
+        return decorateIgnoreDeprecation('nope', $callback);
+    },
+    function () {
+        var_dump(strftime("%Y-%m-%d %H:%M:%S"));
+    }
+));
 --EXPECT--
 string(19) "2012-02-29 01:23:45"

--- a/tests/func_override_011.phpt
+++ b/tests/func_override_011.phpt
@@ -16,7 +16,13 @@ timecop_freeze(timecop_strtotime("2012-02-29 01:23:45 GMT"));
 execute(decorateIfTrue(
     PHP_VERSION_ID >= 80100,
     function (\Closure $callback) {
-        return decorateIgnoreDeprecation('nope', $callback);
+        return decorateIgnoreDeprecation(
+            'Function gmstrftime() is deprecated',
+            decorateIgnoreDeprecation(
+                'Function timecop_gmstrftime() is deprecated',
+                $callback
+            )
+        );
     },
     function () {
         var_dump(gmstrftime("%Y-%m-%d %H:%M:%S"));

--- a/tests/func_override_011.phpt
+++ b/tests/func_override_011.phpt
@@ -9,7 +9,18 @@ date.timezone=America/Los_Angeles
 timecop.func_override=1
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_strtotime("2012-02-29 01:23:45 GMT"));
-var_dump(gmstrftime("%Y-%m-%d %H:%M:%S"));
+
+execute(decorateIfTrue(
+    PHP_VERSION_ID >= 80100,
+    function (\Closure $callback) {
+        return decorateIgnoreDeprecation('nope', $callback);
+    },
+    function () {
+        var_dump(gmstrftime("%Y-%m-%d %H:%M:%S"));
+    }
+));
 --EXPECT--
 string(19) "2012-02-29 01:23:45"

--- a/tests/functions.inc.php
+++ b/tests/functions.inc.php
@@ -1,0 +1,34 @@
+<?php
+
+function decorateIgnoreDeprecation($expectedMessage, \Closure $callback)
+{
+    return function () use ($expectedMessage, $callback) {
+        set_error_handler(function ($code, $message) use ($expectedMessage) {
+            if ($message === $expectedMessage) {
+                return true;
+            }
+
+            return false;
+        }, E_DEPRECATED);
+
+        $result = $callback();
+
+        set_error_handler(null, E_DEPRECATED);
+
+        return $result;
+    };
+}
+
+function decorateIfTrue($condition, \Closure $decorator, Closure $callback)
+{
+    if ($condition) {
+        return $decorator($callback);
+    }
+
+    return $callback;
+}
+
+function execute(\Closure $callback)
+{
+    return $callback();
+}

--- a/tests/immutable_006.phpt
+++ b/tests/immutable_006.phpt
@@ -10,6 +10,8 @@ date.timezone=America/Los_Angeles
 timecop.func_override=0
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(strtotime("2012-02-29 01:23:45"));
 
 // checking class name of instance
@@ -21,7 +23,14 @@ $dts = array(
     timecop_date_create_immutable(),
 
     // constuctor with 1 argument(null)
-    timecop_date_create_immutable(null),
+    execute(decorateIfTrue(PHP_VERSION_ID >= 80100, function (\Closure $callback) {
+        return decorateIgnoreDeprecation(
+            'timecop_date_create_immutable(): Passing null to parameter #1 ($datetime) of type string is deprecated',
+            $callback
+        );
+    }, function () {
+        return timecop_date_create_immutable(null);
+    })),
 
     // constuctor with 1 argument(empty string)
     timecop_date_create_immutable(""),

--- a/tests/immutable_override_006.phpt
+++ b/tests/immutable_override_006.phpt
@@ -10,6 +10,8 @@ date.timezone=America/Los_Angeles
 timecop.func_override=1
 --FILE--
 <?php
+require __DIR__.'/functions.inc.php';
+
 timecop_freeze(timecop_orig_strtotime("2012-02-29 01:23:45"));
 
 // checking class name of instance
@@ -21,7 +23,14 @@ $dts = array(
     date_create_immutable(),
 
     // constuctor with 1 argument(null)
-    date_create_immutable(null),
+    execute(decorateIfTrue(PHP_VERSION_ID >= 80100, function (\Closure $callback) {
+        return decorateIgnoreDeprecation(
+            'timecop_date_create_immutable(): Passing null to parameter #1 ($datetime) of type string is deprecated',
+            $callback
+        );
+    }, function () {
+        return date_create_immutable(null);
+    })),
 
     // constuctor with 1 argument(empty string)
     date_create_immutable(""),

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -1375,6 +1375,15 @@ static void _timecop_datetime_constructor_ex(INTERNAL_FUNCTION_PARAMETERS, zval 
 	const char *real_func;
 	zend_class_entry *real_ce;
 
+#if PHP_VERSION_ID >= 80100
+	ZEND_PARSE_PARAMETERS_START(0, 2)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STRING(orig_time_str, orig_time_len)
+		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(orig_timezone, TIMECOP_G(ce_DateTimeZone))
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_STRINGL(&orig_time, orig_time_str, orig_time_len);
+#else
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|sO!", &orig_time_str, &orig_time_len, &orig_timezone, TIMECOP_G(ce_DateTimeZone)) == FAILURE) {
 		RETURN_FALSE;
 	}
@@ -1384,6 +1393,8 @@ static void _timecop_datetime_constructor_ex(INTERNAL_FUNCTION_PARAMETERS, zval 
 	} else {
 		ZVAL_STRINGL(&orig_time, orig_time_str, orig_time_len);
 	}
+#endif
+
 	if (immutable) {
 		real_func = ORIG_FUNC_NAME("date_create_immutable");
 		real_ce = TIMECOP_G(ce_DateTimeImmutable);

--- a/timecop_php7.c
+++ b/timecop_php7.c
@@ -112,8 +112,13 @@ const zend_function_entry timecop_functions[] = {
 	PHP_FE(timecop_getdate, arginfo_timecop_getdate)
 	PHP_FE(timecop_localtime, arginfo_timecop_localtime)
 	PHP_FE(timecop_strtotime, arginfo_timecop_strtotime)
+#if PHP_VERSION_ID >= 80100
+	PHP_DEP_FE(timecop_strftime, arginfo_timecop_strftime)
+	PHP_DEP_FE(timecop_gmstrftime, arginfo_timecop_gmstrftime)
+#else
 	PHP_FE(timecop_strftime, arginfo_timecop_strftime)
 	PHP_FE(timecop_gmstrftime, arginfo_timecop_gmstrftime)
+#endif
 #ifdef HAVE_GETTIMEOFDAY
 	PHP_FE(timecop_microtime, arginfo_timecop_microtime)
 	PHP_FE(timecop_gettimeofday, arginfo_timecop_gettimeofday)

--- a/timecop_php8_arginfo.h
+++ b/timecop_php8_arginfo.h
@@ -120,7 +120,11 @@ ZEND_END_ARG_INFO()
 
 // TimecopDateTime::createFromFormat()
 #if PHP_VERSION_ID >= 80100
-#define arginfo_class_TimecopDateTime_createFromFormat arginfo_timecop_date_create_from_format
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_TimecopDateTime_createFromFormat, 0, 2, DateTime, MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
+ZEND_END_ARG_INFO()
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_TimecopDateTime_createFromFormat, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
@@ -147,7 +151,11 @@ ZEND_END_ARG_INFO()
 
 // TimecopDateTimeImmutable::createFromFormat
 #if PHP_VERSION_ID >= 80100
-#define arginfo_class_TimecopDateTimeImmutable_createFromFormat arginfo_timecop_date_create_immutable_from_format
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_TimecopDateTimeImmutable_createFromFormat, 0, 2, DateTimeImmutable, MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
+ZEND_END_ARG_INFO()
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_TimecopDateTimeImmutable_createFromFormat, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)

--- a/timecop_php8_arginfo.h
+++ b/timecop_php8_arginfo.h
@@ -121,17 +121,13 @@ ZEND_END_ARG_INFO()
 // TimecopDateTime::createFromFormat()
 #if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_TimecopDateTime_createFromFormat, 0, 2, DateTime, MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
-ZEND_END_ARG_INFO()
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_TimecopDateTime_createFromFormat, 0, 0, 2)
+#endif
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
 ZEND_END_ARG_INFO()
-#endif
 
 // timecop_date_create_immutable()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_timecop_date_create_immutable, 0, 0, DateTimeImmutable, MAY_BE_FALSE)
@@ -152,14 +148,10 @@ ZEND_END_ARG_INFO()
 // TimecopDateTimeImmutable::createFromFormat
 #if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_TimecopDateTimeImmutable_createFromFormat, 0, 2, DateTimeImmutable, MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
-ZEND_END_ARG_INFO()
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_TimecopDateTimeImmutable_createFromFormat, 0, 0, 2)
+#endif
 	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, timezone, DateTimeZone, 1, "null")
 ZEND_END_ARG_INFO()
-#endif


### PR DESCRIPTION
- CI run on PHP 8.1
- Remove support for DateTime constructors to take `null`
- Add helper functions which allow deprecations to be ignored
- Handle null being used as an argument being deprecated
- Account for `{gm,}strftime()` being deprecated in PHP 8.1
- Mark `timecop_{gm,}strftime()` as deprecated on PHP 8.1
- Allow multiple deprecations to be caught
