### PR TITLE
Fix contructors when TZ is set

### DIFF
--- a/tests/issue_timezone_datetime.phpt
+++ b/tests/issue_timezone_datetime.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test that DateTime/DateTimeImmutable respects timezone when no time info provided
+Test that DateTime/DateTimeImmutable respects timezone in constructor
 --SKIPIF--
 <?php
 if (!function_exists('timecop_travel')) die('skip timecop not available');
@@ -8,31 +8,50 @@ date.timezone=Europe/Paris
 timecop.func_override=1
 --FILE--
 <?php
-// When Timecop is active, creating a DateTime with a date string (no time)
-// and a specific timezone should interpret 00:00:00 in that timezone,
+// When Timecop is active, creating a DateTime with a date string
+// and a specific timezone should interpret time in that timezone,
 // not in the default timezone.
 
 \Timecop::travel(new \DateTime());
 
-$dtStart = new DateTimeImmutable('2026-01-30', new DateTimeZone('UTC'));
-$dtStart2 = new DateTime('2026-01-30', new DateTimeZone('UTC'));
+echo "=== Test 1: Date only (no time info) ===\n";
+$date = new DateTimeImmutable('2026-01-30', new DateTimeZone('UTC'));
+$date2 = new DateTime('2026-01-30', new DateTimeZone('UTC'));
 
 // Expected: 2026-01-30 00:00:00 UTC
 // Bug was: 2026-01-29 23:00:00 UTC (midnight Paris time converted to UTC)
 
-echo "DateTimeImmutable: ".$dtStart->format('Y-m-d H:i:s T')."\n";
-echo "DateTime: ".$dtStart2->format('Y-m-d H:i:s T')."\n";
+echo "DateTimeImmutable: ".$date->format('Y-m-d H:i:s T')."\n";
+echo "DateTime: ".$date2->format('Y-m-d H:i:s T')."\n";
 
 // Also test with different timezones
-$dtTokyo = new DateTimeImmutable('2026-01-30', new DateTimeZone('Asia/Tokyo'));
-echo "Asia/Tokyo: ".$dtTokyo->format('Y-m-d H:i:s T')."\n";
+$dateTokyo = new DateTimeImmutable('2026-01-30', new DateTimeZone('Asia/Tokyo'));
+echo "Asia/Tokyo: ".$dateTokyo->format('Y-m-d H:i:s T')."\n";
+
+echo "\n=== Test 2: Date with time info ===\n";
+$dateWithTime = new DateTimeImmutable('2026-01-30 12:00:00', new DateTimeZone('UTC'));
+$dateWithTime2 = new DateTime('2026-01-30 12:00:00', new DateTimeZone('UTC'));
+
+echo "DateTimeImmutable: ".$dateWithTime->format('Y-m-d H:i:s T')."\n";
+echo "DateTime: ".$dateWithTime2->format('Y-m-d H:i:s T')."\n";
+
+// Test with Tokyo timezone and explicit time
+$dateTokyoWithTime = new DateTimeImmutable('2026-01-30 12:00:00', new DateTimeZone('Asia/Tokyo'));
+echo "Asia/Tokyo: ".$dateTokyoWithTime->format('Y-m-d H:i:s T')."\n";
 
 // Ensure original timezone is restored
-echo "Default TZ after: ".date_default_timezone_get()."\n";
+echo "\nDefault TZ after: ".date_default_timezone_get()."\n";
 
 \Timecop::return();
 --EXPECT--
+=== Test 1: Date only (no time info) ===
 DateTimeImmutable: 2026-01-30 00:00:00 UTC
 DateTime: 2026-01-30 00:00:00 UTC
 Asia/Tokyo: 2026-01-30 00:00:00 JST
+
+=== Test 2: Date with time info ===
+DateTimeImmutable: 2026-01-30 12:00:00 UTC
+DateTime: 2026-01-30 12:00:00 UTC
+Asia/Tokyo: 2026-01-30 12:00:00 JST
+
 Default TZ after: Europe/Paris

--- a/tests/issue_timezone_datetime.phpt
+++ b/tests/issue_timezone_datetime.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test that DateTime/DateTimeImmutable respects timezone when no time info provided
+--SKIPIF--
+<?php
+if (!function_exists('timecop_travel')) die('skip timecop not available');
+--INI--
+date.timezone=Europe/Paris
+timecop.func_override=1
+--FILE--
+<?php
+// When Timecop is active, creating a DateTime with a date string (no time)
+// and a specific timezone should interpret 00:00:00 in that timezone,
+// not in the default timezone.
+
+\Timecop::travel(new \DateTime());
+
+$dtStart = new DateTimeImmutable('2026-01-30', new DateTimeZone('UTC'));
+$dtStart2 = new DateTime('2026-01-30', new DateTimeZone('UTC'));
+
+// Expected: 2026-01-30 00:00:00 UTC
+// Bug was: 2026-01-29 23:00:00 UTC (midnight Paris time converted to UTC)
+
+echo "DateTimeImmutable: ".$dtStart->format('Y-m-d H:i:s T')."\n";
+echo "DateTime: ".$dtStart2->format('Y-m-d H:i:s T')."\n";
+
+// Also test with different timezones
+$dtTokyo = new DateTimeImmutable('2026-01-30', new DateTimeZone('Asia/Tokyo'));
+echo "Asia/Tokyo: ".$dtTokyo->format('Y-m-d H:i:s T')."\n";
+
+// Ensure original timezone is restored
+echo "Default TZ after: ".date_default_timezone_get()."\n";
+
+\Timecop::return();
+--EXPECT--
+DateTimeImmutable: 2026-01-30 00:00:00 UTC
+DateTime: 2026-01-30 00:00:00 UTC
+Asia/Tokyo: 2026-01-30 00:00:00 JST
+Default TZ after: Europe/Paris

--- a/timecop.c
+++ b/timecop.c
@@ -694,6 +694,7 @@ static int get_formatted_mock_time(zval *time, zval *timezone_obj, zval *retval_
 	zval now_timestamp, str_now;
 	tc_timeval now;
 	zend_long fixed_usec;
+	int timezone_changed = 0;
 
 	if (TIMECOP_G(timecop_mode) == TIMECOP_MODE_REALTIME) {
 		ZVAL_FALSE(retval_time);
@@ -710,10 +711,29 @@ static int get_formatted_mock_time(zval *time, zval *timezone_obj, zval *retval_
 
 	get_mock_timeval(&now, NULL);
 
-	// @todo Restore removed timezone handling code? https://github.com/kiddivouchers/php-timecop/pull/6
+	/* Temporarily set default timezone to the provided timezone for strtotime */
+	ZVAL_NULL(&orig_zonename);
+	if (timezone_obj != NULL && Z_TYPE_P(timezone_obj) != IS_NULL) {
+		zval zonename;
+		call_php_method_with_0_params(timezone_obj, TIMECOP_G(ce_DateTimeZone), "getname", &zonename);
+		/* Only change timezone for named timezones, not offset-based ones like "+00:00" */
+		if (Z_TYPE(zonename) == IS_STRING && Z_STRLEN(zonename) > 0 &&
+			Z_STRVAL(zonename)[0] != '+' && Z_STRVAL(zonename)[0] != '-') {
+			call_php_function_with_0_params("date_default_timezone_get", &orig_zonename);
+			call_php_function_with_1_params("date_default_timezone_set", NULL, &zonename);
+			timezone_changed = 1;
+		}
+		zval_ptr_dtor(&zonename);
+	}
 
 	ZVAL_LONG(&now_timestamp, now.sec);
 	call_php_function_with_2_params(ORIG_FUNC_NAME("strtotime"), &fixed_sec, time, &now_timestamp);
+
+	/* Restore original default timezone */
+	if (timezone_changed && Z_TYPE(orig_zonename) == IS_STRING) {
+		call_php_function_with_1_params("date_default_timezone_set", NULL, &orig_zonename);
+	}
+	zval_ptr_dtor(&orig_zonename);
 
 	if (Z_TYPE(fixed_sec) == IS_FALSE) {
 		ZVAL_FALSE(retval_time);


### PR DESCRIPTION
Thank you for Timecop, it really makes testing as thorough as can be!

**The Problem:**
When Timecop was active and `new DateTime('2026-01-30', new DateTimeZone('UTC'))` (or `DateTimeImmutable`) was called with a date, the time was incorrectly interpreted as in the default timezone (e.g., `Europe/Paris`) and then converted to UTC, resulting in `2026-01-29 23:00:00 UTC` instead of the correct `2026-01-30 00:00:00 UTC`.

**The Fix (in `timecop.c`):**
Modified the `get_formatted_mock_time()` function to temporarily set the default timezone to the provided timezone before calling `strtotime()`, then restore the original default timezone afterwards. This ensures date strings without explicit time information are correctly interpreted in the specified timezone. The fix also handles edge cases where offset-based timezones (like `+00:00`) are used, skipping the timezone switch for those since `date_default_timezone_set()` doesn't accept them.

**Files Changed:**
- `timecop.c` - Core fix in `get_formatted_mock_time()` function
- `tests/issue_timezone_datetime.phpt` - New test case for this fix

Note : the problem still exists when using offset-based timezones. (`+3:00` etc.)

----

Minimal PHP test to see the problem:

```php
<?php

echo "Default timezone: ".date_default_timezone_get();
echo "\n";

foreach ([true, false] as $activated) {
    if ($activated) {
        \Timecop::travel(new \DateTime());
    } else {
        \Timecop::return();
    }
    echo "Timecop active: ".($activated ? 'yes' : 'no')."\n";

    $dtStart = new DateTimeImmutable('2026-01-30 00:00:00', new DateTimeZone('UTC'));
    $dtStart2 = new DateTime('2026-01-30', new DateTimeZone('UTC'));

    echo $dtStart->format('Y-m-d H:i:s T')." (timestamp: ".$dtStart->getTimestamp().")\n";
    echo $dtStart2->format('Y-m-d H:i:s T')." (timestamp: ".$dtStart->getTimestamp().")\n";

    echo "\n";
}
```

Output : 

```
Default timezone: Europe/Paris
Timecop active: yes
2026-01-29 23:00:00 UTC (timestamp: 1769727600)
2026-01-29 23:00:00 UTC (timestamp: 1769727600)

Timecop active: no
2026-01-30 00:00:00 UTC (timestamp: 1769731200)
2026-01-30 00:00:00 UTC (timestamp: 1769731200)
```